### PR TITLE
Add better workflows api

### DIFF
--- a/app/controllers/workflows_controller.rb
+++ b/app/controllers/workflows_controller.rb
@@ -54,7 +54,6 @@ class WorkflowsController < ApplicationController
               workflow_status_id_map: workflow_status_id_map
            })
         end
-        p 'TRACKERSSS', @trackers
       }
     end
   end

--- a/app/views/workflows/index.api.rsb
+++ b/app/views/workflows/index.api.rsb
@@ -1,0 +1,8 @@
+api.array :trackers do
+  @trackers.each do |tracker|
+    api.tracker do
+        api.tracker_id tracker[:tracker_id]
+        api.workflow_status_id_map tracker[:workflow_status_id_map]
+    end
+  end
+end


### PR DESCRIPTION
Add a better API for retrieving workflows
New endpoint can be found at `/workflows.json`
## Example uses:

**Retrieve all workflows in all projects**
`GET /workflows.json'
Returns

```
"trackers": [
{
  "tracker_id": 1,
  "workflow_status_id_map": {
    "0": [1, 2, 3],
    "1": [2, 3],
    "2": [3]
  }
},
{
  "tracker_id": 2,
  "workflow_status_id_map": {
    "0": [1],
    "1": [2, 3],
    "2": [4],
    "3": [2, 4]
  }
},
{
  "tracker_id": 3,
  "workflow_status_id_map": {
    "0": [1],
    "1": [2, 3],
    "2": [4],
    "3": [2, 4]
  }
}
]
```

**Retrieve all workflows in all projects with specified tracker IDs**
`GET /workflows.json?tracker_ids=1,3'
Returns

```
"trackers": [
{
  "tracker_id": 1,
  "workflow_status_id_map": {
    "0": [1, 2, 3],
    "1": [2, 3],
    "2": [3]
  }
},
{
  "tracker_id": 3,
  "workflow_status_id_map": {
    "0": [1],
    "1": [2, 3],
    "2": [4],
    "3": [2, 4]
  }
}
]
```
